### PR TITLE
Fix for anonymus  acces

### DIFF
--- a/azure-devops-sample/.pipelines/scripts/Generate-Connections.ps1
+++ b/azure-devops-sample/.pipelines/scripts/Generate-Connections.ps1
@@ -92,6 +92,10 @@ Function Get-FunctionConnections {
     if ($function -match "(Invoke url)") {
       $function | select-string -Pattern "Invoke url:" -SimpleMatch | ForEach-Object {
 
+        # Anonymous functions do not have the ?code=xxx suffix
+        if (-not($line.contains('code'))) {
+          $line += '?'
+        }
         $line = $_.Line -replace '\s', ''
         $name = [Regex]::Matches($line, "(?<=api\/)(.*)(?=\?)")
         $trigger = [Regex]::Matches($line, "(?<=url:)(.*)(?=\?)")


### PR DESCRIPTION
In case of an anonymus acces function the Invokeurl is something like
`https://funcxxxxxxx.azurewebsites.net/api/someFunction`

instead of

`https://funcxxxxxx.azurewebsites.net/api/someFunc?code=KftLdW3_D83xc3G9ma6eXzUT_7shgpXLYdMCgjopFrZNAzFuLWYeng==`

The old code did not support the first syntax.